### PR TITLE
Define default values for exported environment parameters

### DIFF
--- a/s2plib/stereo_matching_algo/mgm.py
+++ b/s2plib/stereo_matching_algo/mgm.py
@@ -9,6 +9,11 @@ except ImportError:
 @stereo_matching.StereoMatching.register_subclass('mgm')
 class mgmMatching(stereo_matching.StereoMatching):
 
+    _omp_num_threads = 1
+    _median = 1
+    _census_ncc_win = 5
+    _tsgm = 3
+
     def desc(self):
         print('mgmMatching algorithm')
 
@@ -33,11 +38,17 @@ class mgmMatching(stereo_matching.StereoMatching):
         self._check_disp_range(im_ref, min_disp_range, max_disp_range)
 
         # define environment variables
+        if 'omp_num_threads' in kwargs:
+            self._omp_num_threads = str(kwargs['omp_num_threads'])
+        if 'census_ncc_win' in kwargs:
+            self._census_ncc_win = str(kwargs['census_ncc_win'])
+        varenv = dict()
+        varenv['OMP_NUM_THREADS'] = self._omp_num_threads
+        varenv['MEDIAN'] = self._median
+        varenv['CENSUS_NCC_WIN'] = self._census_ncc_win
+        varenv['TSGM'] = self._tsgm
         env = os.environ.copy()
-        env['OMP_NUM_THREADS'] = str(kwargs['omp_num_threads'])
-        env['MEDIAN'] = '1'
-        env['CENSUS_NCC_WIN'] = str(kwargs['census_ncc_win'])
-        env['TSGM'] = '3'
+        self._export_environment(env, varenv)
 
         conf = '{}_confidence.tif'.format(os.path.splitext(out_disp_path)[0])
         common.run('{0} -r {1} -R {2} -s vfit -t census -O 8 {3} {4} {5} -confidence_consensusL {6}'.format('mgm',
@@ -56,6 +67,12 @@ class mgmMatching(stereo_matching.StereoMatching):
 
 @stereo_matching.StereoMatching.register_subclass('mgm_multi')
 class mgm_multiMatching(stereo_matching.StereoMatching):
+
+    _omp_num_threads = 1
+    _stereo_speckle_filter = 25
+    _mindiff = 1
+    _census_ncc_win = 5
+    _subpix = 2
 
     def desc(self):
         print('mgm_multiMatching algorithm')
@@ -81,12 +98,21 @@ class mgm_multiMatching(stereo_matching.StereoMatching):
         self._check_disp_range(im_ref, min_disp_range, max_disp_range)
 
         # define environment variables
+        if 'omp_num_threads' in kwargs:
+            self._omp_num_threads = str(kwargs['omp_num_threads'])
+        if 'stereo_speckle_filter' in kwargs:
+            self._stereo_speckle_filter = str(kwargs['stereo_speckle_filter'])
+        if 'census_ncc_win' in kwargs:
+            self._census_ncc_win = str(kwargs['census_ncc_win'])
+
+        varenv = dict()
+        varenv['OMP_NUM_THREADS'] = self._omp_num_threads
+        varenv['REMOVESMALLCC'] = self._stereo_speckle_filter
+        varenv['MINDIFF']= self._mindiff
+        varenv['CENSUS_NCC_WIN'] = self._census_ncc_win
+        varenv['SUBPIX'] = self._subpix
         env = os.environ.copy()
-        env['OMP_NUM_THREADS'] = str(kwargs['omp_num_threads'])
-        env['REMOVESMALLCC'] = str(kwargs['stereo_speckle_filter'])
-        env['MINDIFF'] = '1'
-        env['CENSUS_NCC_WIN'] = str(kwargs['census_ncc_win'])
-        env['SUBPIX'] = '2'
+        self._export_environment(env, varenv)
 
         # it is required that p2 > p1. The larger p1, p2, the smoother the disparity
         # TODO

--- a/s2plib/stereo_matching_algo/msmw.py
+++ b/s2plib/stereo_matching_algo/msmw.py
@@ -11,6 +11,8 @@ except ImportError:
 @stereo_matching.StereoMatching.register_subclass('msmw3')
 class msmwMatching(stereo_matching.StereoMatching):
 
+    _omp_num_threads = 1
+
     def desc(self):
         print('msmwMatching algorithm')
 
@@ -35,8 +37,12 @@ class msmwMatching(stereo_matching.StereoMatching):
         self._check_disp_range(im_ref, min_disp_range, max_disp_range)
 
         # define environment variables
+        if 'omp_num_threads' in kwargs:
+            self._omp_num_threads = str(kwargs['omp_num_threads'])
+        varenv = dict()
+        varenv['OMP_NUM_THREADS'] = self._omp_num_threads
         env = os.environ.copy()
-        env['OMP_NUM_THREADS'] = str(kwargs['omp_num_threads'])
+        self._export_environment(env, varenv)
 
         bm_binary = 'msmw'
         common.run('{0} -m {1} -M {2} -il {3} -ir {4} -dl {5} -kl {6}'.format(

--- a/s2plib/stereo_matching_algo/stereo_matching.py
+++ b/s2plib/stereo_matching_algo/stereo_matching.py
@@ -108,6 +108,12 @@ class StereoMatching(object):
 
         return disp_min, disp_max
 
+    @staticmethod
+    def _export_environment(env, varenv):
+        for key, value in varenv.iteritems():
+            env[key] = str(value)
+
+
 
 if __name__ == '__main__':
     """


### PR DESCRIPTION
Context
------------
Define default values for parameters used in matching algorithm. This development has been made in order to enhance the PR made on miss3D, as mentionned in its comments. 

Note
--------
Default values have been defined for a whole class of stereo matching. 
The environment exportation is implemented as a static function in the base class. This function does not depend on the object nor the class, but it is common to all classes derived from the base class. 
I have not linked the environment variables to the stereo matching objects for the following reasons. These variables should have been inside a dictionnary, which is a non mutable type. Thus, it could only have been defined inside function compute_disparity_map, and not at the same level as a class attribute, to avoid being shared by all instances of the class. Once it is defined inside the function, it seems to me lighter to just pass it as an argument to the function, rather than linking it to the object.